### PR TITLE
Support ability to edit task details without deletion

### DIFF
--- a/data/duke.txt
+++ b/data/duke.txt
@@ -1,3 +1,3 @@
-T | 0 | study
-D | 0 | return book | 2/12/2019 1800
-E | 0 | project meeting | Mon 2pm | 4pm
+T | 1 | borrow book
+D | 0 | return study | 2/12/2019 1800
+E | 0 | study | tues 6pm | wed 6pm

--- a/src/main/java/duke/CommandType.java
+++ b/src/main/java/duke/CommandType.java
@@ -8,5 +8,6 @@ public enum CommandType {
     LIST,
     MARK,
     DELETE,
-    FIND
+    FIND,
+    UPDATE,
 }

--- a/src/main/java/duke/Deadline.java
+++ b/src/main/java/duke/Deadline.java
@@ -10,8 +10,8 @@ import java.time.format.DateTimeParseException;
  */
 public class Deadline extends IndividualTask {
 
-    private final String returnBy;
-    private final LocalDateTime formatReturnBy;
+    private String returnBy;
+    private LocalDateTime formatReturnBy;
 
     /**
      * Constructs a {@code Deadline} object with the specified task description and return by date/time.
@@ -25,6 +25,10 @@ public class Deadline extends IndividualTask {
         this.formatReturnBy = parseDateTime(returnBy);
     }
 
+    public void setReturnBy(String returnBy) {
+        this.returnBy = returnBy;
+        this.formatReturnBy = parseDateTime(this.returnBy);
+    }
     /**
      * Parses the date/time string into a {@code LocalDateTime} object.
      *

--- a/src/main/java/duke/Event.java
+++ b/src/main/java/duke/Event.java
@@ -6,8 +6,8 @@ package duke;
  */
 public class Event extends IndividualTask {
 
-    private final String from;
-    private final String to;
+    private String from;
+    private String to;
 
     /**
      * Constructs an {@code Event} object with the specified task description, start time, and end time.
@@ -19,6 +19,12 @@ public class Event extends IndividualTask {
     public Event(String taskDescription, String from, String to) {
         super(taskDescription);
         this.from = from;
+        this.to = to;
+    }
+    public void setFrom(String from) {
+        this.from = from;
+    }
+    public void setTo(String to) {
         this.to = to;
     }
 

--- a/src/main/java/duke/IndividualTask.java
+++ b/src/main/java/duke/IndividualTask.java
@@ -7,7 +7,7 @@ package duke;
  */
 public abstract class IndividualTask {
 
-    private final String taskDescription;
+    private String taskDescription;
     private boolean isTaskDone;
 
     /**
@@ -18,6 +18,10 @@ public abstract class IndividualTask {
     public IndividualTask(String taskDescription) {
         this.taskDescription = taskDescription;
         this.isTaskDone = false;
+    }
+
+    public void setTaskDescription(String taskDescription) {
+        this.taskDescription = taskDescription;
     }
 
     /**

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -47,6 +47,10 @@ public class Parser {
             return new Command(
                     CommandType.FIND.toString().toLowerCase(),
                     command);
+        } else if (command.strip().toLowerCase().contains(CommandType.UPDATE.toString().toLowerCase())) {
+            return new Command(
+                    CommandType.UPDATE.toString().toLowerCase(),
+                    command);
         } else {
             return new Command(command, command);
         }


### PR DESCRIPTION
Currently, the application requires users to delete and recreate a task to make changes, which is not user-friendly and time-consuming. Editing details like the end time of an event or description of a task should not require complete removal of the task.

To address this, I have implemented a feature allowing users to update specific fields of `ToDo`, `Deadline`, and `Event` tasks. Now, users can modify details such as the description, deadline, or event times without having to delete the entire task.

Key changes:
* Added a method `handleUpdateCommand` to handle update logic.
* Supported the ability to update fields like description, 'by' (deadline), and event start/end times using field-specific update methods.
* Ensured that multi-word values can be provided using string concatenation logic for the update command.

This improvement enhances usability, allowing more efficient task management without unnecessary task deletion and re-creation.